### PR TITLE
RobotControl: Write jsonstate out via i2c

### DIFF
--- a/RobotControl/CommsI2C.cpp
+++ b/RobotControl/CommsI2C.cpp
@@ -1,0 +1,60 @@
+#include "CommsI2C.h"
+#include <Wire.h>
+
+const size_t CommsI2C::I2C_MAX_BYTES = 32;
+
+CommsI2C::CommsI2C(int myAddress, int deviceAddress) {
+  m_myAddress = myAddress;
+  m_deviceAddress = deviceAddress;
+}
+
+void CommsI2C::init() {
+  Wire.begin(m_myAddress);
+}
+
+void CommsI2C::beginWrite() {
+  m_totalBytesWritten = 0;
+  m_messageBytesWritten = 0;
+  Wire.beginTransmission(m_deviceAddress);
+}
+
+size_t CommsI2C::endWrite() {
+  Wire.endTransmission();
+  return m_totalBytesWritten;
+}
+
+void CommsI2C::sendState(JsonState &state) {
+  beginWrite();
+  state.printJson(*this);
+  size_t bytesWritten = endWrite();
+  Serial.print("--- ");
+  Serial.print(bytesWritten);
+  Serial.println(" total bytes written ---");
+}
+
+// TODO: Fill out for receiving data
+int CommsI2C::available() {
+  return 0;
+}
+
+// TODO: Fill out for receiving data
+int CommsI2C::read() {
+  return 0;
+}
+
+// TODO: Fill out for receiving data
+int CommsI2C::peek() {
+  return 0;
+}
+
+size_t CommsI2C::write(uint8_t value) {
+  if (m_messageBytesWritten == I2C_MAX_BYTES) {
+    // We're at max message size. Stop this one and start the next.
+    Wire.endTransmission();
+    Wire.beginTransmission(m_deviceAddress);
+    m_messageBytesWritten = 0;
+  }
+  Wire.write(value);
+  m_messageBytesWritten++;
+  m_totalBytesWritten++;
+}

--- a/RobotControl/CommsI2C.cpp
+++ b/RobotControl/CommsI2C.cpp
@@ -27,9 +27,6 @@ void CommsI2C::sendState(JsonState &state) {
   beginWrite();
   state.printJson(*this);
   size_t bytesWritten = endWrite();
-  Serial.print("--- ");
-  Serial.print(bytesWritten);
-  Serial.println(" total bytes written ---");
 }
 
 // TODO: Fill out for receiving data

--- a/RobotControl/CommsI2C.h
+++ b/RobotControl/CommsI2C.h
@@ -1,0 +1,31 @@
+#ifndef COMMSI2C_H
+#define COMMSI2C_H
+
+#include <Arduino.h>
+#include <JsonEl.h>
+
+class CommsI2C : public Stream {
+  public:
+    static const size_t I2C_MAX_BYTES;
+
+    CommsI2C(int myAddress, int deviceAddress);
+
+    void init();
+    void sendState(JsonState &state);
+
+    void beginWrite();
+    size_t endWrite();
+
+    virtual int available();
+    virtual int read();
+    virtual int peek();
+    virtual size_t write(uint8_t ch);
+
+  private:
+    int m_myAddress;
+    int m_deviceAddress;
+    size_t m_messageBytesWritten;
+    size_t m_totalBytesWritten;
+};
+
+#endif // COMMSI2C_H

--- a/RobotControl/Robot.h
+++ b/RobotControl/Robot.h
@@ -4,24 +4,26 @@
 #include <Arduino.h>
 #include <JsonEl.h>
 #include "StatusLEDs.h"
+#include "CommsI2C.h"
 
 #define ROBOT_TICK_DURATION_BUFFER_LEN 5
 
 class Robot {
   static const unsigned long TICK_DURATION_MICROS;
+  static const unsigned long I2C_UPDATE_TICKS;
 
   static const char *STATUS_DISABLED;
   static const char *STATUS_ENABLED;
   static const char *STATUS_PRIMED;
 
   public:
-    Robot(JsonState &state, int pinLedBuiltin);
+    Robot(JsonState &state, int pinLedBuiltin, int i2cHostAddress, int i2cDeviceAddress);
 
     void init();
     void update();
 
   private:
-    void updateSerial(int ticks);
+    void updateSerial();
     void updateFromJson(const char *json);
     int getAverageTickDuration();
     void updateTickDurations(int tickDurationMicros);
@@ -29,6 +31,7 @@ class Robot {
 
     JsonState &m_state;
     StatusLEDs m_statusLEDs;
+    CommsI2C m_commsI2C;
     int m_initTimeSeconds;
     int m_tickDurations[ROBOT_TICK_DURATION_BUFFER_LEN];
     size_t m_tickDurationsIndex;

--- a/RobotControl/RobotControl.ino
+++ b/RobotControl/RobotControl.ino
@@ -12,6 +12,8 @@
 #include "StatusLEDs.h"
 
 #define SERIAL_BAUD_RATE   115200
+#define I2C_HOST_ADDRESS   0x04
+#define I2C_DEVICE_ADDRESS 0x08
 #define PIN_LED_BUILTIN    LED_BUILTIN
 
 // Set up the JSON State for the robot
@@ -47,7 +49,7 @@ JsonElement robotState = Json::Object(robotStateFields);
 
 JsonState state(robotState);
 
-Robot robot(state, PIN_LED_BUILTIN);
+Robot robot(state, PIN_LED_BUILTIN, I2C_HOST_ADDRESS, I2C_DEVICE_ADDRESS);
 
 // Primary Setup
 void setup() {


### PR DESCRIPTION
This writes the current jsonstate object via i2c in 32-byte chunks.

Note: The tick rate will have to be adjusted after this, as this takes a bit of processing.