### PR TITLE
Add robot comms

### DIFF
--- a/RobotComms/RobotComms.ino
+++ b/RobotComms/RobotComms.ino
@@ -1,0 +1,152 @@
+#include <Wire.h>
+#include <RHReliableDatagram.h>
+#include <RH_RF95.h>
+#include <SPI.h>
+#include <Speck.h>
+#include <RHEncryptedDriver.h>
+
+#include "I2CBufferStack.h"
+
+#define SOFTWARE_VERSION   "0.1.0"
+
+#define SERIAL_BAUD_RATE   115200
+#define I2C_DEVICE_ADDRESS 0x08
+
+#define ROBOT_STATE_MAXLEN 300
+
+// Defines for the 900MHz radio
+#define RFM95_CS   8
+#define RFM95_RST  4
+#define RFM95_INT  3
+#define RF95_FREQ  915.0
+#define RF95_POWER 23
+
+#define RADIO_ACK_RETRIES  1
+#define RADIO_ACK_TIMEOUT  100
+
+#define CONTROLLER_ADDRESS 1
+#define ROBOT_ADDRESS 2
+
+#define I2C_BUFFER_COUNT 12
+
+const char *JSON_PREAMBLE = "~~~";
+
+// Singleton instance of the radio driver
+RH_RF95 raw_driver(RFM95_CS, RFM95_INT);
+Speck myCipher;
+unsigned char encryptkey[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+RHEncryptedDriver driver(raw_driver, myCipher);
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, ROBOT_ADDRESS);
+
+char message[] = "Test Message";
+char radioBuffer[RH_RF95_MAX_MESSAGE_LEN];
+uint8_t radioBufferIndex = -1;
+
+bool isControllerConnected = false;
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+
+  Serial.begin(SERIAL_BAUD_RATE);
+  while (!Serial) {} // Wait for serial port to be available
+
+  Serial.print("--- Robot Comms v");
+  Serial.print(SOFTWARE_VERSION);
+  Serial.println(" ---");
+
+  if (!manager.init()) {
+    Serial.println("init failed");
+    while (1) {}
+  }
+
+  manager.setRetries(RADIO_ACK_RETRIES);
+  manager.setTimeout(RADIO_ACK_TIMEOUT);
+
+  if (!raw_driver.setFrequency(RF95_FREQ)) {
+    Serial.println("setFrequency failed");
+    while (1) {}
+  }
+
+  myCipher.setKey(encryptkey, sizeof(encryptkey));
+
+  raw_driver.setTxPower(RF95_POWER, false);
+
+  Wire.begin(I2C_DEVICE_ADDRESS);
+  Wire.onReceive(receiveEvent);
+  Serial.println("--- Init Complete ---");
+}
+
+void loop()
+{
+  //uint8_t len = sizeof(buf);
+  //uint8_t from;
+
+  /*
+  if (manager.available())
+  {
+    Serial.println("Robot received a message");
+    // Wait for a message addressed to us from the client
+
+    if (manager.recvfromAckTimeout(buf, &len, 2000, &from))
+    {
+      Serial.println(String(from));
+
+      // Send a reply back to the originator client
+      if (!manager.sendtoWait((uint8_t*)message, strlen(message) + 1, CONTROLLER_ADDRESS))
+        connect();
+    }
+  }
+  */
+}
+
+bool isPreamble(const char *data) {
+  return strncmp(data, JSON_PREAMBLE, strlen(JSON_PREAMBLE)) == 0;
+}
+
+boolean sendRadioMessage(uint8_t* message, uint8_t length, uint8_t address) {
+  digitalWrite(LED_BUILTIN, HIGH);
+  bool success = manager.sendtoWait(message, length, address);
+  if (success) {
+    isControllerConnected = true;
+    digitalWrite(LED_BUILTIN, LOW);
+    return true;
+  } else {
+    isControllerConnected = false;
+    digitalWrite(LED_BUILTIN, LOW);
+    return false;
+  }
+}
+
+void receiveEvent(int howMany) {
+  char buffer[33];
+  size_t byteCount = 0;
+
+  while (byteCount < 32 && Wire.available()) {
+    buffer[byteCount] = Wire.read();
+    byteCount++;
+  }
+  buffer[byteCount] = '\0';
+
+  if (isPreamble(buffer)) {
+    if (radioBufferIndex >= 0) {
+      radioBuffer[radioBufferIndex + 1] = '\0';
+      sendRadioMessage((uint8_t*)radioBuffer, strlen(radioBuffer) + 1, CONTROLLER_ADDRESS);
+    }
+
+    radioBufferIndex = 0;
+    return;
+  }
+
+  if (radioBufferIndex >= 0) {
+    if (byteCount > (RH_RF95_MAX_MESSAGE_LEN - radioBufferIndex)) {
+      Serial.println("ERROR: Radio buffer overflow!");
+      return;
+    }
+    memcpy(radioBuffer + radioBufferIndex, buffer, byteCount);
+    radioBufferIndex += byteCount;
+  }
+}

--- a/RobotComms/RobotComms.ino
+++ b/RobotComms/RobotComms.ino
@@ -7,22 +7,11 @@
 #define SERIAL_BAUD_RATE   115200
 #define I2C_DEVICE_ADDRESS 0x08
 
-#define ROBOT_STATE_MAXLEN 300
-
 // Defines for the 900MHz radio
 #define RFM95_CS   8
-#define RFM95_RST  4
 #define RFM95_INT  3
 #define RF95_FREQ  915.0
 #define RF95_POWER 23
-
-#define RADIO_ACK_RETRIES  1
-#define RADIO_ACK_TIMEOUT  100
-
-#define CONTROLLER_ADDRESS 1
-#define ROBOT_ADDRESS 2
-
-#define I2C_BUFFER_COUNT 12
 
 const char *JSON_PREAMBLE = "~~~";
 
@@ -70,7 +59,7 @@ bool isPreamble(const char *data) {
   return strncmp(data, JSON_PREAMBLE, strlen(JSON_PREAMBLE)) == 0;
 }
 
-void sendRadioMessage(uint8_t* message, uint8_t length, uint8_t address) {
+void sendRadioMessage(uint8_t* message, uint8_t length) {
   digitalWrite(LED_BUILTIN, HIGH);
   rf95.send(message, length);
   rf95.waitPacketSent();
@@ -90,7 +79,7 @@ void receiveEvent(int howMany) {
   if (isPreamble(buffer)) {
     if (radioBufferIndex >= 0) {
       radioBuffer[radioBufferIndex + 1] = '\0';
-      sendRadioMessage((uint8_t*)radioBuffer, strlen(radioBuffer) + 1, CONTROLLER_ADDRESS);
+      sendRadioMessage((uint8_t*)radioBuffer, strlen(radioBuffer) + 1);
     }
 
     radioBufferIndex = 0;

--- a/RobotComms/package.json
+++ b/RobotComms/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "RobotComms",
+  "version": "0.1.0",
+  "description": "FRC 2357 Arduino Robot 900 MHz Comms System",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frc2357/arduino-2357.git"
+  },
+  "keywords": [
+    "arduino"
+  ],
+  "author": "System Meltdown FRC2357",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/frc2357/arduino-2357/issues"
+  },
+  "homepage": "https://github.com/frc2357/arduino-2357#readme",
+  "arduinoLibs": [
+    "../3rd-party-libraries/RadioHead",
+    "../3rd-party-libraries/Crypto",
+    "../3rd-party-libraries/CryptoLW"
+  ]
+}

--- a/RobotControl/CommsI2C.cpp
+++ b/RobotControl/CommsI2C.cpp
@@ -2,6 +2,7 @@
 #include <Wire.h>
 
 const size_t CommsI2C::I2C_MAX_BYTES = 32;
+const char *CommsI2C::JSON_PREAMBLE = "~~~";
 
 CommsI2C::CommsI2C(int myAddress, int deviceAddress) {
   m_myAddress = myAddress;
@@ -25,9 +26,13 @@ size_t CommsI2C::endWrite() {
 
 void CommsI2C::sendState(JsonState &state) {
   beginWrite();
+  this->print(JSON_PREAMBLE);
+  endWrite();
+
+  beginWrite();
   state.printJson(*this, true);
   state.clearChanged();
-  size_t bytesWritten = endWrite();
+  endWrite();
 }
 
 // TODO: Fill out for receiving data

--- a/RobotControl/CommsI2C.h
+++ b/RobotControl/CommsI2C.h
@@ -7,6 +7,7 @@
 class CommsI2C : public Stream {
   public:
     static const size_t I2C_MAX_BYTES;
+    static const char *JSON_PREAMBLE;
 
     CommsI2C(int myAddress, int deviceAddress);
 

--- a/RobotControl/RobotControl.ino
+++ b/RobotControl/RobotControl.ino
@@ -26,6 +26,7 @@ JsonElement robotStateFields[] = {
   Json::Int("v", SOFTWARE_VERSION),
   Json::Int("t", 0),
   Json::String("status", "Disabled"),
+  Json::Boolean("hCtl", false),
   Json::Object("eStop", eStopFields),
   Json::Float("b", 0.0),
   Json::Int("ang", 0),

--- a/TestController/TestController.ino
+++ b/TestController/TestController.ino
@@ -1,0 +1,93 @@
+#include <RHReliableDatagram.h>
+#include <RH_RF95.h>
+#include <SPI.h>
+#include <Speck.h>
+#include <RHEncryptedDriver.h>
+
+//for feather m0
+#define RFM95_CS 8
+#define RFM95_RST 4
+#define RFM95_INT 3
+#define RF95_FREQ 915.0
+
+#define CONTROLLER_ADDRESS 1
+#define ROBOT_ADDRESS 2
+
+#define RECEIVE_TIMEOUT 1000
+
+RH_RF95 raw_driver(RFM95_CS, RFM95_INT);
+Speck myCipher;
+unsigned char encryptkey[16] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+RHEncryptedDriver driver(raw_driver, myCipher);
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, CONTROLLER_ADDRESS);
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+
+  Serial.begin(115200);
+  while (!Serial) {} // Wait for serial port to be available
+
+  if (!manager.init()) {
+    Serial.println("init failed");
+    while (1) {}
+  }
+
+  if (!raw_driver.setFrequency(RF95_FREQ)) {
+    Serial.println("setFrequency failed");
+    while (1) {}
+  }
+
+  myCipher.setKey(encryptkey, sizeof(encryptkey));
+
+  // The default transmitter power is 13dBm, using PA_BOOST.
+  // If you are using RFM95/96/97/98 modules which uses the PA_BOOST transmitter pin, then
+  // you can set transmitter powers from 5 to 23 dBm:
+  raw_driver.setTxPower(23, false);
+
+  Serial.println("Finished init");
+}
+
+uint8_t data[] = "I am the first one";
+uint8_t inputBuffer[RH_RF95_MAX_MESSAGE_LEN];
+
+void loop()
+{
+  uint8_t inputLen = RH_RF95_MAX_MESSAGE_LEN;
+  uint8_t from;
+
+  digitalWrite(LED_BUILTIN, HIGH);
+  if (manager.recvfromAckTimeout(inputBuffer, &inputLen, RECEIVE_TIMEOUT, &from))
+  {
+    if (from == ROBOT_ADDRESS) {
+      digitalWrite(LED_BUILTIN, LOW);
+      receiveRobotStatus((const char *)inputBuffer, inputLen);
+    }
+  } else {
+    digitalWrite(LED_BUILTIN, LOW);
+    Serial.println("Waiting to connect to robot...");
+  }
+
+  /*
+  if (!manager.sendtoWait(data, sizeof(data), ROBOT_ADDRESS)) {
+    Serial.println("sendtoWait failed");
+  }
+  */
+}
+
+void receiveRobotStatus(const char *buf, uint8_t len) {
+  Serial.print("Robot Status: \"");
+  Serial.print((char*)inputBuffer);
+  Serial.println("\"");
+}
+
+bool connect()
+{
+  while (!manager.sendtoWait(data, sizeof(data), ROBOT_ADDRESS)) {
+    Serial.println("Controller not found");
+  }
+  return true;
+}

--- a/TestController/TestController.ino
+++ b/TestController/TestController.ino
@@ -2,14 +2,8 @@
 
 //for feather m0
 #define RFM95_CS 8
-#define RFM95_RST 4
 #define RFM95_INT 3
 #define RF95_FREQ 915.0
-
-#define CONTROLLER_ADDRESS 1
-#define ROBOT_ADDRESS 2
-
-#define RECEIVE_TIMEOUT 1000
 
 RH_RF95 rf95(RFM95_CS, RFM95_INT);
 

--- a/TestController/package.json
+++ b/TestController/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "TestController",
+  "version": "0.1.0",
+  "description": "FRC 2357 Arduino Robot 900 MHz Test Controller",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frc2357/arduino-2357.git"
+  },
+  "keywords": [
+    "arduino"
+  ],
+  "author": "System Meltdown FRC2357",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/frc2357/arduino-2357/issues"
+  },
+  "homepage": "https://github.com/frc2357/arduino-2357#readme",
+  "arduinoLibs": [
+    "../3rd-party-libraries/RadioHead",
+    "../3rd-party-libraries/Crypto",
+    "../3rd-party-libraries/CryptoLW"
+  ]
+}


### PR DESCRIPTION
First functional send of JSON state all the way from RobotControls through i2c to RobotComms to TestController.

As of right now, it's not polished and full iterations are taking around 450ms, which is too long, so that needs to be brought in to under 100ms if possible:

Ideas:
1. Stop using radio messages that require ACKs.
2. Try removing encryption to see if that gains us speed.
3. Stop sending full JSON state messages and send partial ones instead.
4. Send full JSON state messages at a lower rate, and use a more terse format for joystick controls.
